### PR TITLE
feat: Add support for linting @nuxtjs/sanity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "lts/*"
+node_js: "10.22.1"
 cache: yarn
 install: yarn --ignore-engines
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+- **BREAKING CHANGE**: Set minimum Node version to 10.0.0
+- Adds support for linting `groq` exported by `@nuxtjs/sanity`
+
 ## 0.1.2
 
 - Fixes wrong plugin name in recommended config

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ npm install groq @asbjorn/eslint-plugin-groq
 
 ## Requirements
 
-This plugin uses [`groq`](https://www.npmjs.com/package/groq) to identify GROQ tagged template literals, and will not report anything for queries that don't use `groq`. Install it from [here](https://www.npmjs.com/package/groq).
+Only supports linting GROQ tagged template literals using these packages:
+
+* [`groq`](https://www.npmjs.com/package/groq)
+* [`@nuxtjs/sanity`](https://www.npmjs.com/package/@nuxtjs/sanity)
+
+Other GROQ imports will not be linted.
 
 ```js
 // Will not be linted:
@@ -20,6 +25,14 @@ const query = groq`*[_type == 'movies'][0..10]`;
 
 // Will also be linted:
 import anything from "groq";
+const query = anything`*[_type == 'movies'][0..10]`;
+
+// Will also be linted:
+import { groq } from "@nuxtjs/sanity";
+const query = groq`*[_type == 'movies'][0..10]`;
+
+// Will also be linted:
+import { groq as anything } from "@nuxtjs/sanity";
 const query = anything`*[_type == 'movies'][0..10]`;
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@asbjorn/eslint-plugin-groq",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "Eslint plugin for GROQ queries",
   "author": "Asbjørn Hegdahl",
   "license": "MIT",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/asbjornh/eslint-plugin-groq.git"

--- a/rules/no-syntax-errors.test.js
+++ b/rules/no-syntax-errors.test.js
@@ -21,20 +21,28 @@ const validCases = [
 
   // Valid query
   "import groq from 'groq'; q = groq`*[_type == 'movie']`",
+  "import { groq } from '@nuxtjs/sanity'; q = groq`*[_type == 'movie']`",
 
-  // Invalid query tagged with `groq` not from the `groq` package
+  // Valid query (not imported as 'groq')
+  "import hello from 'groq'; q = hello`*[_type == 'movie']`",
+  "import { groq as hello } from '@nuxtjs/sanity'; q = hello`*[_type == 'movie']`",
+
+  // Invalid query tagged with `groq` not from either of the supported packages
   "import groq from 'somewhere'; q = groq`*[_type == {]`",
 
   // Invalid query with template expression
-  "import groq from 'groq'; q = groq`*[_${expression} == {]`"
+  "import groq from 'groq'; q = groq`*[_${expression} == {]`",
+  "import { groq } from '@nuxtjs/sanity'; q = groq`*[_${expression} == {]`",
 ];
 
 const invalidCases = [
   // Syntax error
   ['import groq from "groq"; groq`*[_type == { ]`', { line: 1, column: 44 }],
+  ['import { groq } from "@nuxtjs/sanity"; groq`*[_type == { ]`', { line: 1, column: 58 }],
 
   // Syntax error (not imported as 'groq')
   ["import hello from 'groq'; q = hello`*[_type == { ]`"],
+  ["import { groq as hello } from '@nuxtjs/sanity'; q = hello`*[_type == { ]`"],
 
   // Syntax error (import all)
   ["import * as groq from 'groq'; q = groq`*[_type == { ]`"],
@@ -45,6 +53,17 @@ const invalidCases = [
   // Multiline with syntax error
   [
     `import groq from "groq";
+groq\`*[_type == 'movie']{
+  name
+  year
+}
+\`;
+  `,
+    { line: 4, column: 3 }
+  ],
+
+  [
+    `import { groq } from "@nuxtjs/sanity";
 groq\`*[_type == 'movie']{
   name
   year

--- a/rules/no-template-expressions.test.js
+++ b/rules/no-template-expressions.test.js
@@ -18,6 +18,7 @@ const validCases = [
 
   // Tagged query without expressions
   "import groq from 'groq'; q = groq`*[_type == 'movie']`",
+  "import { groq } from '@nuxtjs/sanity'; q = groq`*[_type == 'movie']`",
 
   // Non-tagged query with expression
   "`*[_type == ${type}]`",
@@ -29,9 +30,11 @@ const validCases = [
 const invalidCases = [
   // Template expression
   'import groq from "groq"; groq`*[_type == ${type}]`',
+  'import { groq } from "@nuxtjs/sanity"; groq`*[_type == ${type}]`',
 
   // Template expression (not imported as 'groq')
   "import hello from 'groq'; q = hello`*[_type == ${type}]`",
+  "import { groq as hello } from '@nuxtjs/sanity'; q = hello`*[_type == ${type}]`",
 
   // Template expression (import all)
   "import * as groq from 'groq'; q = groq`*[_type == ${type}]`",

--- a/utils/groq-visitor.js
+++ b/utils/groq-visitor.js
@@ -1,5 +1,10 @@
 const astUtils = require("eslint-ast-utils");
 
+const knownGroqs = [
+  "groq",
+  "@nuxtjs/sanity"
+];
+
 /** Expects a function that returns a visitor object. This function is called with a function for checking whether a given tagged template expression is tagged with `groq` */
 module.exports = function groqVisitor(visitorFn) {
   // NOTE: Dictionary with identifier names as keys and import paths as values
@@ -9,7 +14,7 @@ module.exports = function groqVisitor(visitorFn) {
   const isGroqQuery = node =>
     node.type === "TaggedTemplateExpression" &&
     node.tag.type === "Identifier" &&
-    imports[node.tag.name] === "groq" &&
+    knownGroqs.includes(imports[node.tag.name]) &&
     node.quasi.type === "TemplateLiteral";
 
   return Object.assign(


### PR DESCRIPTION
Hi!

Thanks for your work on this plugin. I understand if you want to keep
things simple, but I figured I'd send a PR with some changes that would
help me get an extra layer of safety in a project I'm working on in [Nuxt](https://sanity.nuxtjs.org/).
Since these changes may be helpful to others as well I wanted to run
them by you. I figure since this plugin is [listed here](https://www.sanity.io/plugins/groq-eslint) most users will want
to install this version and not a (theoretical) fork for Nuxt support.

The Nuxt community module for Sanity integration brings its own export
of `groq` to be a "batteries included" experience. While a plugin for
VS Code can bring syntax highlighting it would be nice to have the
option of using this existing ESLint plugin to lint GROQ in projects
using `@nuxtjs/sanity` without duplicating `groq`.

This commit adds some suggested changes to add support for this other
import. It adds a minimum required Node version in `engines`.